### PR TITLE
Add Athena customer management module

### DIFF
--- a/addons/athena_customer/__init__.py
+++ b/addons/athena_customer/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/athena_customer/__manifest__.py
+++ b/addons/athena_customer/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': 'Athena Customer Management',
+    'version': '16.0.1.0.0',
+    'summary': 'Manage Athena products and customers',
+    'description': 'Module to manage Athena products and customers with multilingual support.',
+    'author': 'Paul Lu',
+    'website': 'https://www.example.com',
+    'category': 'Sales/CRM',
+    'depends': ['base'],
+    'data': [
+        'security/athena_groups.xml',
+        'security/ir.model.access.csv',
+        'views/athena_menus.xml',
+        'views/athena_product_views.xml',
+        'views/athena_customer_views.xml',
+    ],
+    'application': True,
+    'license': 'LGPL-3',
+}

--- a/addons/athena_customer/i18n/en_US.po
+++ b/addons/athena_customer/i18n/en_US.po
@@ -1,0 +1,10 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: athena_customer\n"
+"POT-Creation-Date: 2023-01-01 00:00+0000\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# English translations (placeholder)

--- a/addons/athena_customer/i18n/zh_TW.po
+++ b/addons/athena_customer/i18n/zh_TW.po
@@ -1,0 +1,10 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: athena_customer\n"
+"POT-Creation-Date: 2023-01-01 00:00+0000\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Chinese translations (placeholder)

--- a/addons/athena_customer/models/__init__.py
+++ b/addons/athena_customer/models/__init__.py
@@ -1,0 +1,2 @@
+from . import athena_product
+from . import athena_customer

--- a/addons/athena_customer/models/athena_customer.py
+++ b/addons/athena_customer/models/athena_customer.py
@@ -1,0 +1,26 @@
+from odoo import models, fields
+
+
+class AthenaCustomer(models.Model):
+    _name = 'athena.customer'
+    _description = 'Athena Customer'
+
+    name = fields.Char(string='Customer Name', required=True)
+    address = fields.Char(string='Address')
+    contact_person = fields.Char(string='Contact Person')
+    phone = fields.Char(string='Phone')
+    product_line_ids = fields.One2many(
+        'athena.customer.product.line',
+        'customer_id',
+        string='Products'
+    )
+
+
+class AthenaCustomerProductLine(models.Model):
+    _name = 'athena.customer.product.line'
+    _description = 'Customer Product Line'
+
+    customer_id = fields.Many2one('athena.customer', string='Customer', ondelete='cascade')
+    product_id = fields.Many2one('athena.product', string='Product', required=True)
+    purchase_date = fields.Date(string='Purchase Date')
+    salesperson_id = fields.Many2one('res.users', string='Salesperson')

--- a/addons/athena_customer/models/athena_product.py
+++ b/addons/athena_customer/models/athena_product.py
@@ -1,0 +1,14 @@
+from odoo import models, fields
+
+
+class AthenaProduct(models.Model):
+    _name = 'athena.product'
+    _description = 'Athena Product'
+
+    name = fields.Char(string='Product Name', required=True)
+    category = fields.Selection(
+        [('A6', 'A6'), ('A7', 'A7')],
+        string='Category',
+        required=True,
+        default='A6'
+    )

--- a/addons/athena_customer/security/athena_groups.xml
+++ b/addons/athena_customer/security/athena_groups.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="group_athena_user" model="res.groups">
+        <field name="name">Athena User</field>
+        <field name="category_id" ref="base.module_category_sales"/>
+    </record>
+
+    <record id="group_athena_manager" model="res.groups">
+        <field name="name">Athena Manager</field>
+        <field name="implied_ids" eval="[(4, ref('group_athena_user'))]"/>
+        <field name="category_id" ref="base.module_category_sales"/>
+    </record>
+</odoo>

--- a/addons/athena_customer/security/ir.model.access.csv
+++ b/addons/athena_customer/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_athena_product_manager,access.athena.product.manager,model_athena_product,athena_customer.group_athena_manager,1,1,1,1
+access_athena_customer_user,access.athena.customer.user,model_athena_customer,athena_customer.group_athena_user,1,1,1,1
+access_athena_customer_line_user,access.athena.customer.product.line.user,model_athena_customer_product_line,athena_customer.group_athena_user,1,1,1,1

--- a/addons/athena_customer/views/athena_customer_views.xml
+++ b/addons/athena_customer/views/athena_customer_views.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_athena_customer_tree" model="ir.ui.view">
+        <field name="name">athena.customer.tree</field>
+        <field name="model">athena.customer</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="address"/>
+                <field name="contact_person"/>
+                <field name="phone"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_athena_customer_form" model="ir.ui.view">
+        <field name="name">athena.customer.form</field>
+        <field name="model">athena.customer</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="address"/>
+                        <field name="contact_person"/>
+                        <field name="phone"/>
+                    </group>
+                    <notebook>
+                        <page string="Products">
+                            <field name="product_line_ids">
+                                <tree editable="bottom">
+                                    <field name="product_id"/>
+                                    <field name="purchase_date"/>
+                                    <field name="salesperson_id"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_athena_customer_search" model="ir.ui.view">
+        <field name="name">athena.customer.search</field>
+        <field name="model">athena.customer</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="address"/>
+                <field name="contact_person"/>
+                <field name="phone"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_athena_customer" model="ir.actions.act_window">
+        <field name="name">Athena Customers</field>
+        <field name="res_model">athena.customer</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create the first customer
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/athena_customer/views/athena_menus.xml
+++ b/addons/athena_customer/views/athena_menus.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <menuitem id="athena_main_menu" name="Athena" sequence="10" groups="athena_customer.group_athena_user"/>
+
+    <menuitem id="athena_customer_menu" name="Customers" parent="athena_main_menu"
+              action="athena_customer.action_athena_customer" sequence="10"
+              groups="athena_customer.group_athena_user"/>
+
+    <menuitem id="athena_product_menu" name="Products" parent="athena_main_menu"
+              action="athena_customer.action_athena_product" sequence="20"
+              groups="athena_customer.group_athena_manager"/>
+</odoo>

--- a/addons/athena_customer/views/athena_product_views.xml
+++ b/addons/athena_customer/views/athena_product_views.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_athena_product_tree" model="ir.ui.view">
+        <field name="name">athena.product.tree</field>
+        <field name="model">athena.product</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="category"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_athena_product_form" model="ir.ui.view">
+        <field name="name">athena.product.form</field>
+        <field name="model">athena.product</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="category"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_athena_product_search" model="ir.ui.view">
+        <field name="name">athena.product.search</field>
+        <field name="model">athena.product</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="category"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_athena_product" model="ir.actions.act_window">
+        <field name="name">Athena Products</field>
+        <field name="res_model">athena.product</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create the first product
+            </p>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add a new `athena_customer` module
- define product and customer models with relations
- create security groups and access rules
- add menus and views for products and customers
- provide placeholder translations

## Testing
- `python -m py_compile addons/athena_customer/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68407e6491e48328bc3de27b7d7b8aae